### PR TITLE
Add --provider flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Laravel HTMLMin supports optional configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="GrahamCampbell\HTMLMin\HTMLMinServiceProvider"
 ```
 
 This will create a `config/htmlmin.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
I think especially a lot of people that are new to Laravel don't know that they can use the `--provider` flag to just publish assets for a single package so this should make this more clear.